### PR TITLE
ci: use node v22

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -12,7 +12,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [16.x]
+        node-version: [22.x]
 
     permissions:
       contents: read


### PR DESCRIPTION
Use node v22 in GitHub actions workflow